### PR TITLE
Prevent cores' lava to be removed by water buckets

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/cores/CoreObjective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/cores/CoreObjective.java
@@ -389,7 +389,7 @@ public class CoreObjective implements GameObjective {
 
     @EventHandler
     public void onBucketEmpty(PlayerBucketEmptyEvent event) {
-        if (region.contains(event.getBlockClicked().getLocation()) && event.getBucket() == Material.LAVA_BUCKET)
+        if (region.contains(event.getBlockClicked().getRelative(event.getBlockFace()).getLocation()) && event.getBlockClicked().getRelative(event.getBlockFace()).getType() == Material.STATIONARY_LAVA)
             event.setCancelled(true);
     }
 


### PR DESCRIPTION
It prevents buckets to be placed inside lava (both water buckets and lava buckets)
As it is right now in cardinal, you can't place lava arround the core, and you can place water inside lava,
Additonally, you can place lava in the core region if you are clicking in a block outside of the region, but not against a block that's inside the core
